### PR TITLE
Minor recommended shortening of ddev's config.yaml

### DIFF
--- a/src/components/CodeGenerator.svelte
+++ b/src/components/CodeGenerator.svelte
@@ -27,16 +27,9 @@ type: wordpress
 docroot: ""
 php_version: "${$selectedPhpVersion}"
 webserver_type: ${$webServerType}
-router_http_port: "80"
-router_https_port: "443"
-xdebug_enabled: false
-additional_hostnames: []
-additional_fqdns: []
 ${$selectedDbVersionType}: "${$selectedDbVersionNumber}"
 nfs_mount_enabled: false
 mutagen_enabled: false
-use_dns_when_possible: true
-composer_version: "2"
 web_environment:
 - PRODUCTION_SSH_HOST=${$sshHost}
 - PRODUCTION_SSH_USER=${$sshUser}


### PR DESCRIPTION
The items with default values (or that people are unlikely to change) don't really need to be included. In a perfect world they'd also stop being included in the normal ddev generated config.yaml

Another option you might consider is using ddev to generate the config.yaml, for example `ddev config --php-version=8.0 --mariadb-version=10.3...`